### PR TITLE
Feature/track answers

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -37,6 +37,10 @@ img.logo {
   }
 }
 
+.opacity-30 {
+  opacity: 0.3;
+}
+
 .zoom {
   zoom: 1.5;
   -moz-transform: scale(1.5);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,8 +33,10 @@ const App = () => {
     let newGroups = [...questionGroups];
     for (let group of newGroups) {
       for (let question of group.questions) {
-        if (question.question === response.question)
+        if (question.question === response.question) {
           question.confidence = response.confidence;
+          question.previousConfidence = response.previousConfidence;
+        }
       }
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ const App = () => {
 
   const [useEmoji, setUseEmoji] = useState<boolean>(true);
   const [tickSymbol, setTickSymbol] = useState<string>('✓');
+  const [showChanges, setShowChanges] = useState<boolean>(true);
   const [questionGroups, setQuestionGroups] = useState<QuestionGroup[]>(
     questionGroupsFromHash
   );
@@ -84,7 +85,9 @@ const App = () => {
       <Menu
         useEmoji={useEmoji}
         selectedSymbol={tickSymbol}
+        showChanges={showChanges}
         onUseEmojiToggled={setUseEmoji}
+        onShowChangesToggled={setShowChanges}
         onSymbolSelected={setTickSymbol}
       />
 
@@ -104,6 +107,7 @@ const App = () => {
           questionGroups={questionGroups}
           tickSymbol={tickSymbol}
           useEmoji={useEmoji}
+          showChanges={showChanges}
           handleSelection={handleSelection}
         />
       </div>

--- a/src/DataTypes.tsx
+++ b/src/DataTypes.tsx
@@ -1,6 +1,7 @@
-import { Confidence } from "./utils/Confidence";
+import { Confidence } from './utils/Confidence';
 
 export interface QuestionResponse {
+  previousConfidence: Confidence | undefined;
   confidence: Confidence | undefined;
   question: string;
 }

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -11,7 +11,7 @@ export interface MenuProps {
   onSymbolSelected: (args: string) => void;
 }
 
-const symbols: string[] = ['✓', '✔', '✘', '❌', '✅', '★', '🎵', '🔴'];
+const symbols: string[] = ['✓', '✔', '✘', '✅', '★', '🎵', '🔵'];
 
 const Menu: React.FC<MenuProps> = ({
   useEmoji,

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -5,7 +5,9 @@ import { faCog } from '@fortawesome/free-solid-svg-icons';
 export interface MenuProps {
   useEmoji: boolean;
   selectedSymbol: string;
+  showChanges: boolean;
   onUseEmojiToggled: (args: boolean) => void;
+  onShowChangesToggled: (args: boolean) => void;
   onSymbolSelected: (args: string) => void;
 }
 
@@ -14,6 +16,8 @@ const symbols: string[] = ['✓', '✔', '✘', '❌', '✅', '★', '🎵', '�
 const Menu: React.FC<MenuProps> = ({
   useEmoji,
   selectedSymbol: tickSymbol,
+  showChanges,
+  onShowChangesToggled,
   onUseEmojiToggled,
   onSymbolSelected,
 }) => {
@@ -31,12 +35,28 @@ const Menu: React.FC<MenuProps> = ({
           <FontAwesomeIcon icon={faCog} />
         </button>
         <div className="dropdown-menu" aria-labelledby="dropdownMenuButton">
-          <span
-            className="dropdown-item pointer"
-            onClick={() => onUseEmojiToggled(!useEmoji)}
-          >
-            {useEmoji ? 'Text Headings' : 'Emoji Headings'}
-          </span>
+          <div className="checkbox dropdown-item">
+            <label>
+              <input
+                className="mr-2"
+                type="checkbox"
+                checked={useEmoji}
+                onClick={() => onUseEmojiToggled(!useEmoji)}
+              />
+              Use Emoji
+            </label>
+          </div>
+          <div className="checkbox dropdown-item">
+            <label>
+              <input
+                className="mr-2"
+                type="checkbox"
+                checked={showChanges}
+                onClick={() => onShowChangesToggled(!showChanges)}
+              />
+              Show Changes
+            </label>
+          </div>
           <div className="dropdown-divider"></div>
           {symbols.map((symbol) => {
             return (

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -15,18 +15,29 @@ export const Question: React.FC<QuestionResponseProps> = ({
   questionNo,
   callback,
 }) => {
-  let buttons = ConfidenceLevels.map((confidence) => {
-    let value = {
+  const buttons = ConfidenceLevels.map((confidence) => {
+    const isSelected = response.confidence === confidence;
+    const value = {
+      previousConfidence: response.confidence,
       confidence: confidence,
       question: response.question,
     };
     return (
       <td
         key={confidence}
-        onClick={() => callback(value)}
+        onClick={() => (isSelected ? null : callback(value))}
         className="td-check m-0 p-0 align-middle"
       >
-        {response.confidence === confidence ? tickSymbol ?? '✓' : null}
+        <div className="p-0">
+          <span className="m-0">
+            {response.confidence === confidence ? tickSymbol ?? '✓' : null}
+          </span>
+          <span className="m-0 opacity-30">
+            {response.previousConfidence === confidence
+              ? tickSymbol ?? '✓'
+              : null}
+          </span>
+        </div>
       </td>
     );
   });

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -2,17 +2,19 @@ import { QuestionResponse } from '../DataTypes';
 import { ConfidenceLevels } from '../utils/Confidence';
 import React from 'react';
 
-export interface QuestionResponseProps {
+export interface QuestionProps {
   response: QuestionResponse;
   tickSymbol: string;
   questionNo: number | undefined;
+  showChanges?: boolean;
   callback: (response: QuestionResponse) => void;
 }
 
-export const Question: React.FC<QuestionResponseProps> = ({
+export const Question: React.FC<QuestionProps> = ({
   response,
   tickSymbol,
   questionNo,
+  showChanges,
   callback,
 }) => {
   const buttons = ConfidenceLevels.map((confidence) => {
@@ -32,11 +34,13 @@ export const Question: React.FC<QuestionResponseProps> = ({
           <span className="m-0">
             {response.confidence === confidence ? tickSymbol ?? '✓' : null}
           </span>
-          <span className="m-0 opacity-30">
-            {response.previousConfidence === confidence
-              ? tickSymbol ?? '✓'
-              : null}
-          </span>
+          {showChanges ? (
+            <span className="m-0 opacity-30">
+              {response.previousConfidence === confidence
+                ? tickSymbol ?? '✓'
+                : null}
+            </span>
+          ) : null}
         </div>
       </td>
     );

--- a/src/components/Questionnaire.tsx
+++ b/src/components/Questionnaire.tsx
@@ -8,6 +8,7 @@ interface QuestionnaireProps {
   questionGroups: QuestionGroup[];
   tickSymbol: string;
   useEmoji?: boolean;
+  showChanges?: boolean;
   handleSelection: (response: QuestionResponse) => void;
 }
 
@@ -15,6 +16,7 @@ export const Questionnaire: React.FC<QuestionnaireProps> = ({
   questionGroups,
   tickSymbol,
   useEmoji,
+  showChanges,
   handleSelection,
 }) => (
   <table className="table table-bordered table-hover ">
@@ -37,6 +39,7 @@ export const Questionnaire: React.FC<QuestionnaireProps> = ({
                   tickSymbol={tickSymbol}
                   response={question}
                   questionNo={lineNo}
+                  showChanges={showChanges}
                   callback={handleSelection}
                 />
               );


### PR DESCRIPTION
I expanded the question response interface to include the previous confidence selection. The previous selection is displayed using the same symbol as the normal selection but with 30% opacity. The option to show the previous confidence can be toggled from the menu.